### PR TITLE
fix for db date error

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Database connection settings
-spring.datasource.url=jdbc:mysql://localhost:3306/${CONSTRUCTIONESTIMATOR_DB_NAME}
+spring.datasource.url=jdbc:mysql://localhost:3306/${CONSTRUCTIONESTIMATOR_DB_NAME}?serverTimezone=UTC
 spring.datasource.username=${CONSTRUCTIONESTIMATOR_USERNAME}
 spring.datasource.password=${CONSTRUCTIONESTIMATOR_PASSWORD}
 


### PR DESCRIPTION
This fixed an error about time zones related to connecting to my local mysql db.

This is the error that I received when running bootstrap:
```
Caused by: com.mysql.cj.exceptions.InvalidConnectionAttributeException: The server time zone value 'CDT' is unrecognized or represents more than one time zone. You must configure either the server or JDBC driver (via the 'serverTimezone' configuration property) to use a more specifc time zone value if you want to utilize time zone support.
```